### PR TITLE
make run importable 

### DIFF
--- a/renview/__init__.py
+++ b/renview/__init__.py
@@ -3,6 +3,8 @@
 ReNView
 """
 
+from .run import run
+
 ####
 #
 # setuptools likes to see a name for the package,


### PR DESCRIPTION
Makes it possible to run renview from any user folder 
```
import renview
kwargs = { ... }
renview.run(**kwargs)
```